### PR TITLE
Prevent KeyNotValidException for some Huawei devices

### DIFF
--- a/android-keystore-compat-base/src/main/kotlin/cz/koto/keystorecompat/base/KeystoreCompatBase.kt
+++ b/android-keystore-compat-base/src/main/kotlin/cz/koto/keystorecompat/base/KeystoreCompatBase.kt
@@ -266,7 +266,7 @@ abstract class KeystoreCompatBase(open val config: KeystoreCompatConfigBase, ope
 	private fun createNewKeyPair(aliasText: String) {
 		try {
 			val start = Calendar.getInstance()
-			start.add(Calendar.MINUTE, -1)//Prevent KeyNotYetValidException for encryption
+			start.add(Calendar.DAY_OF_YEAR, -1)//Prevent KeyNotYetValidException for encryption
 			val end = Calendar.getInstance()
 			end.add(Calendar.YEAR, 1)//TODO handle with outdated certificates!
 			keystoreCompatImpl.generateKeyPair(aliasText, start.time, end.time, this.certSubject, this.context)


### PR DESCRIPTION
There is an issue with some Huawei devices with KeyNotValidException (which is apparently related to incorrect work with TimeZones)

We have that bug on few our devices and it's hard to reproduce them. So I suggest to make a slight correction of key start date to prevent that crash event in theory. 

Here you can find discussion about that bug

https://github.com/iamMehedi/Secured-Preference-Store/issues/15
